### PR TITLE
Fixed: closing mobile menu

### DIFF
--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -287,6 +287,10 @@ textarea {
     &:extend(.nav);
     &:extend(.navbar-nav);
 
+    @media (max-width: @screen-sm-min) {
+      clear: both;
+    }
+
     & > li {
       &:extend(.nav > li);
       &:extend(.navbar-nav > li);


### PR DESCRIPTION
It was impossible to close the mobile menu as the first app-item overlapped with the menu icon.
