### PR TITLE
Form macros

### DIFF
--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -213,24 +213,17 @@ button, input[type="button"], input[type="submit"] {
   &.button-cancel, &[name="cancel"] {
     &:extend(.btn-default);
   }
+}
 
-  &.button-in-sidebar {
+.sidebar form button[type="submit"] {
     &:extend(a);
-    &:extend(.list-group-item);
-    &:extend(.panel > .list-group .list-group-item);
-
-    width: 100%;
-    text-align: left;
-    margin-top: 0;
-
-    &:first-child {
-      &:extend(.panel > .list-group:first-child .list-group-item:first-child);
-    }
-
     &:hover, &:focus {
-      &:extend(list-group-item:focus);
+      &:extend(a:hover, a:focus);
     }
-  }
+
+    border: none;
+    padding:0;
+    margin: 0;
 }
 
 input[type="text"], input[type="email"], input[type="password"], select {

--- a/inyoka_theme_default/templates/macros.html
+++ b/inyoka_theme_default/templates/macros.html
@@ -211,50 +211,6 @@
   </div>
 {% endmacro %}
 
-{% macro render_form(form, fields, inline = false) %}
-  {% if not inline %}
-    <dl>
-  {% endif %}
-  {% for field in fields %}
-    {% if form[field] %}
-      <dt>
-        <label for="{{ form[field].auto_id }}">{{ form[field].label }}:</label>
-      </dt>
-      <dd>
-        {{ form[field] }} {{ form.errors[field] }}
-        {% if form[field].help_text %}
-          <p class="text-info">{{ form[field].help_text }}</p>
-        {% endif %}
-      </dd>
-    {% endif %}
-  {% endfor %}
-  {% if not inline %}
-    </dl>
-  {% endif %}
-{% endmacro %}
-
-{% macro render_checkbox_form(form, fields, inline = false) %}
-  {% if not inline %}
-    <dl>
-  {% endif %}
-  {% for field in fields %}
-    {% if form[field] %}
-      <dd>
-        {{ form[field] }}
-        <label for="{{ form[field].auto_id }}">{{ form[field].label }}</label>
-        {{ form.errors[field] }}
-        {% if form[field].help_text %}
-          <p class="text-info">{{ form[field].help_text }}</p>
-        {% endif %}
-      </dd>
-    {% endif %}
-  {% endfor %}
-  {% if not inline %}
-    </dl>
-  {% endif %}
-{% endmacro %}
-
-
 {# OTHER #}
 
 {% macro add_user_avatar(user) %}

--- a/inyoka_theme_default/templates/macros.html
+++ b/inyoka_theme_default/templates/macros.html
@@ -51,6 +51,7 @@
   </li>
 {% endmacro %}
 
+
 {# BREADCRUMB #}
 
 {% macro breadcrumb_item(label, url) %}
@@ -62,6 +63,7 @@
     <li>{{ label }}</li>
   {% endif %}
 {% endmacro %}
+
 
 {# PAGINATION #}
 
@@ -108,6 +110,107 @@
 {% endmacro %}
 
 
+{# FORM #}
+
+{% macro outer_form(csrf, form=None, bootstrap_class=None, action="", method="post", submit_label=None, manually_rendered=False) %}
+{# params
+    * csrf: just give `csrf_token()` (workaround for a context-bug)
+    * form: if given and manually_rendered not touched, all fields will be rendered
+            Even if you want to render this form manually, it is worth to pass this parameter.
+            Thus, errors not associated with any field will be still rendered.
+    * bootstrap_class: f.e. `form-horizontal` or `form-inline` see http://getbootstrap.com/css/#forms
+                            `None` if default boostrap-behaviour wished
+    * action: HTML-action-url
+    * method: default: `post`, alternative `get`
+              (latter will generate an URL from the fields. It will look like ?<name>=<value>.
+              So it will be visible in browser-history. Do not use for sensible information (passwords etc.)!)
+    * submit_label: text for submit-button
+    * manually_rendered: disable automatic rendering of all form-fields by setting this True
+#}
+    <form action="{{ action }}" method="{{ method }}"
+    {% if bootstrap_class %} class="{{ bootstrap_class }}" {% endif %}
+    {% if form and form.is_multipart() %} enctype="multipart/form-data" {% endif %}> {# for uploading files (images etc.) #}
+      {% if method.lower() == "post" %} {{ csrf }} {% endif %}
+
+      {% if form %}
+        {{ form.non_field_errors() }}
+        {% if not manually_rendered %}
+          {{ inner_form(form) }}
+        {% endif %}
+      {% endif %}
+
+      {% if caller %}
+        {{ caller() }}
+      {% endif %}
+
+      <button type="submit">
+        {% if submit_label %}
+          {{ submit_label }}
+        {% else %}
+          {% trans %}Submit{% endtrans %}
+        {% endif %}
+      </button>
+    </form>
+{% endmacro %}
+
+{% macro inner_form(form, custom_fields=None) %}
+{#
+  can be used with call outer_form(…) to do things "manually"
+
+  if no list for custom_fields are given, all fields of @form will be rendered.
+  Otherwise all fields in custom_fields will be rendered (in the given order, too).
+#}
+  {% if form %}
+    {% if custom_fields %}
+      {% for field in custom_fields %}
+        {% if form[field] %}
+          {{ render_field_by_type(form[field]) }}
+        {% endif %}
+      {% endfor %}
+
+    {% else %}
+        {% for field in form %}
+          {{ render_field_by_type(field) }}
+        {% endfor %}
+    {% endif %}
+  {% endif %}
+{% endmacro %}
+
+{% macro render_field_by_type(field) %}
+  {% if field.field.widget|ischeckbox %}
+    {{ checkbox(field) }}
+  {% else %}
+    {{ input(field) }}
+  {% endif %}
+{% endmacro %}
+
+{% macro checkbox(field) %}
+  {% if field.errors %}
+  <div class="has-error">
+    {{ field.errors }}
+  {% endif %}
+
+    <div class="checkbox">
+      <label>
+        {{ field }} {{ field.label }}
+      </label>
+    </div>
+
+  {% if field.errors %} </div> {% endif %}
+{% endmacro %}
+
+{% macro input(field) %}
+  <div class="form-group {% if field.errors %} has-error {% endif %}">
+    {{ field.errors }}
+    {{ field.label_tag() }}
+    {{ field }}
+
+    {% if field.help_text %}
+      <p class="help-block">{{ field.help_text }}</p>
+    {% endif %}
+  </div>
+{% endmacro %}
+
 {% macro render_form(form, fields, inline = false) %}
   {% if not inline %}
     <dl>
@@ -150,6 +253,9 @@
     </dl>
   {% endif %}
 {% endmacro %}
+
+
+{# OTHER #}
 
 {% macro add_user_avatar(user) %}
   {% if user.avatar_url %}

--- a/inyoka_theme_default/templates/macros.html
+++ b/inyoka_theme_default/templates/macros.html
@@ -133,7 +133,7 @@
       {% if method.lower() == "post" %} {{ csrf }} {% endif %}
 
       {% if form %}
-        {{ form.non_field_errors() }}
+        {{ render_errors(form.non_field_errors()) }}
         {% if not manually_rendered %}
           {{ inner_form(form) }}
         {% endif %}
@@ -187,7 +187,7 @@
 {% macro checkbox(field) %}
   {% if field.errors %}
   <div class="has-error">
-    {{ field.errors }}
+    {{ render_errors(field.errors) }}
   {% endif %}
 
     <div class="checkbox">
@@ -201,14 +201,24 @@
 
 {% macro input(field) %}
   <div class="form-group {% if field.errors %} has-error {% endif %}">
-    {{ field.errors }}
     {{ field.label_tag() }}
+    {{ render_errors(field.errors) }}
     {{ field }}
 
     {% if field.help_text %}
       <p class="help-block">{{ field.help_text }}</p>
     {% endif %}
   </div>
+{% endmacro %}
+
+{% macro render_errors(error_list) %}
+  {% if error_list %}
+    {% for error in error_list %}
+      <p class="help-block">
+        {{ error }}
+      </p>
+    {% endfor %}
+  {% endif %}
 {% endmacro %}
 
 {# OTHER #}

--- a/inyoka_theme_default/templates/pastebin/add.html
+++ b/inyoka_theme_default/templates/pastebin/add.html
@@ -10,28 +10,21 @@
     :license: BSD, see LICENSE for more details.
 #}
 {% extends 'pastebin/base.html' %}
-{% from 'macros.html' import render_form %}
+{% from 'macros.html' import breadcrumb_item, outer_form %}
 
 {% block breadcrumb %}
   {{ super() }}
-  <li><a href="{{ href('pastebin', 'add') }}">{% trans %}New paste{% endtrans %}</a></li>
+
+  {{ breadcrumb_item(_('New paste'), href('pastebin', 'add')) }}
 {% endblock %}
 
+
 {% block paste_content %}
-  <form action="" method="post">
-    {{ csrf_token() }}
-    <dl>
-      <dt>{% trans %}About:{% endtrans %}</dt>
-      <dd>{% trans %}
-        This is a pastebin where you can save error messages, logs, configuration files or source codes to keep threads or IRC channels clean. To do this, just copy the text in the box below and choose the appropriate language. After that, you copy the URL into the topic or the channel.
-      {% endtrans %}</dd>
-      {{ render_form(form, ['title', 'lang', 'code'], inline=True) }}
-      {% if not USER.is_authenticated() %}
-      {{ render_form(form, ['captcha'], inline=True) }}
-      {% endif %}
-      <dd>
-        <input type="submit" value="{% trans %}Submit{% endtrans %}" />
-      </dd>
-    </dl>
-  </form>
+  <p>
+    {% trans %}
+    This is a pastebin where you can save error messages, logs, configuration files or source codes to keep threads or IRC channels clean. To do this, just copy the text in the box below and choose the appropriate language. After that, you copy the URL into the topic or the channel.
+    {% endtrans %}
+  </p>
+
+  {{ outer_form(csrf_token(), form) }}
 {% endblock %}

--- a/inyoka_theme_default/templates/pastebin/delete_entry.html
+++ b/inyoka_theme_default/templates/pastebin/delete_entry.html
@@ -9,16 +9,14 @@
     :license: BSD, see LICENSE for more details.
 #}
 
+{% from 'macros.html' import outer_form %}
 
-<form action="{{ entry|url('delete')|e }}" method="post">
-  {{ csrf_token() }}
+{% call outer_form(csrf_token(), action=entry|url('delete')|e, submit_label=_('Delete')) %}
   <p>
     {% trans link=entry|url, entry=entry.title|e %}
       Do you really want to delete the entry <a href="{{ link }}">{{ entry }}</a>?
     {% endtrans %}
   </p>
-  <p>
-    <input type="submit" class="button-delete" value="{% trans %}Delete{% endtrans %}" />
-    <input type="submit" name="cancel" value="{% trans %}Cancel{% endtrans %}" />
-  </p>
-</form>
+
+  <input type="submit" name="cancel" value="{% trans %}Cancel{% endtrans %}" />
+{% endcall %}

--- a/inyoka_theme_default/templates/planet/blog_edit.html
+++ b/inyoka_theme_default/templates/planet/blog_edit.html
@@ -9,8 +9,7 @@
 #}
 {% extends 'planet/base.html' %}
 
-{% from 'macros.html' import render_form %}
-{% set scripts = ['jquery.autocomplete'] %}
+{% from 'macros.html' import render_form, outer_form %}
 
 {% block breadcrumb %}
   {{ super() }}
@@ -20,13 +19,5 @@
 {% endblock %}
 
 {% block content %}
-  <form action="" method="post" enctype="multipart/form-data">
-    {{ csrf_token() }}
-    <dl>
-      {{ render_form(form, ['name', 'description', 'blog_url', 'feed_url', 'active', 'user', 'icon'], inline=True) }}
-    </dl>
-    <p>
-      <input type="submit" value="{% trans %}Submit{% endtrans %}" />
-    </p>
-  </form>
+  {{ outer_form(csrf_token(), form) }}
 {% endblock %}

--- a/inyoka_theme_default/templates/planet/blog_edit.html
+++ b/inyoka_theme_default/templates/planet/blog_edit.html
@@ -9,7 +9,7 @@
 #}
 {% extends 'planet/base.html' %}
 
-{% from 'macros.html' import render_form, outer_form %}
+{% from 'macros.html' import outer_form %}
 
 {% block breadcrumb %}
   {{ super() }}

--- a/inyoka_theme_default/templates/planet/hide_entry.html
+++ b/inyoka_theme_default/templates/planet/hide_entry.html
@@ -8,8 +8,12 @@
   :copyright: (c) 2013-2015 by the Inyoka Team, see AUTHORS for more details.
   :license: BSD, see LICENSE for more details.
 -#}
-<form action="{{ href('planet', 'hide', entry.id)|e }}" method="post">
-  {{ csrf_token() }}
+
+{% from 'macros.html' import outer_form %}
+
+{% set tmp_label = _('Restore') if entry.hidden else _('Hide') %}
+
+{% call outer_form(csrf_token(), action=href('planet', 'hide', entry.id)|e, submit_label=tmp_label) %}
   <p>
     {% if entry.hidden %}
       {% trans %}Are you sure you want to restore the entry?{% endtrans %}
@@ -17,14 +21,6 @@
       {% trans %}Are you sure you want to hide the entry?{% endtrans %}
     {% endif %}
   </p>
-  <p> 
-    <input type="submit" value="
-      {% if entry.hidden %}
-        {% trans %}Restore{% endtrans %}
-      {% else %}
-        {% trans %}Hide{% endtrans %}
-      {% endif %}"
-    />
-    <input type="submit" name="cancel" value="{% trans %}Cancel{% endtrans %}" />
-  </p>
-</form>
+  
+  <input type="submit" name="cancel" value="{% trans %}Cancel{% endtrans %}" />
+{% endcall %}

--- a/inyoka_theme_default/templates/planet/suggest.html
+++ b/inyoka_theme_default/templates/planet/suggest.html
@@ -9,7 +9,7 @@
 #}
 {% extends 'planet/base.html' %}
 
-{% from 'macros.html' import render_form %}
+{% from 'macros.html' import outer_form %}
 
 {% block breadcrumb %}
   {{ super() }}
@@ -19,24 +19,8 @@
 
 {% block planet_content %}
   <h3>{% trans %}With this form you can suggest a new blog for the planet.{% endtrans %}</h3>
-  <p>Die wichtigsten Kriterien sind:</p>
-  <ul>
-    <li>Ubuntu/Linux-bezogener Inhalt, bei gemischtem Inhalt muss ein separater Feed zur Verfügung gestellt werden.</li>
-    <li>Der Feed muss den gesamten Beitrag enthalten.</li>
-    <li>Der Blog sollte mindestens 2 Monate alt sein und in dieser Zeit regelmäßig und passend zum Thema berichtet haben.</li>
-    <li>Die Beiträge dürfen keine Werbung enthalten.</li>
-    <li>Die Beiträge müssen in deutscher Sprache verfasst sein.</li>
-  </ul>
   <p>{% trans %}Please be patient. It could take a while, until we approve your suggestion.{% endtrans %}</p>
-  <form action="{{ href('planet', 'suggest') }}" method="post">
-    {{ csrf_token() }}
-    <dl>
-      {{ render_form(form, ['name', 'url', 'feed_url', 'description', 'contact_email'], inline=True) }}
-      <dd>{{ form.mine }} <label for="id_mine">{{ form.mine.label|e }}</label></dd>
-    </dl>
-    <p>
-      <input type="submit" value="{% trans %}Submit{% endtrans %}" />
-      <input type="submit" name="cancel" value="{% trans %}Cancel{% endtrans %}" />
-    </p>
-  </form>
+  
+  {% call outer_form(csrf_token(), form, action=href('planet', 'suggest')) %}
+  {% endcall %}
 {% endblock %}

--- a/inyoka_theme_default/templates/portal/login.html
+++ b/inyoka_theme_default/templates/portal/login.html
@@ -18,57 +18,18 @@
 
 {% block content %}
   <h2>{% trans %}Login{% endtrans %}</h2>
-  {{ form.errors }}
-  <form action="" method="post">
-    {{ csrf_token() }}
-    <div class="form-group">
+  {{ macros.outer_form(csrf_token(), form, submit_label=_('Sign in')) }}
 
-      <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
-      <input
-          type="text"
-          id="{{ form.username.id_for_label }}"
-          name="{{ form.username.html_name }}"
-          {% if form.username.value() %}value="{{ form.username.value()|e }}"{% endif %}
-          placeholder="{% trans %}Username{% endtrans %}"
-          tabindex="10">
-    </div>
-    <div class="form-group">
-      <label for="{{ form.password.id_for_label }}">{{ form.password.label }}</label>
-      <input type="password" id="{{ form.password.id_for_label }}"
-             name="{{ form.password.html_name }}"
-             placeholder="{% trans %}Password{% endtrans %}" tabindex="20">
-    </div>
-    <div class="checkbox">
-      <label>
-        <input type="checkbox"
-               id="{{ form.permanent.id_for_label }}"
-               name="{{ form.permanent.html_name }}"
-               {% if form.permanent.value() %}checked{% endif %}
-               tabindex="30"> {{ form.permanent.label }}
-      </label>
-
-      <p class="help-block">
-        {% trans %}
-          Don’t choose this option if you are using a public computer. Otherwise, unauthorized persons may
-          enter your account.
-        {% endtrans %}
-      </p>
-    </div>
-
-    <input type="hidden" name="redirect" value="" />
-    <input type="submit" id="login" value="{% trans %}Sign in{% endtrans %}"
-           tabindex="40" />
-  </form>
   <small class="text-muted">
     <ul class="list-unstyled">
       <li>
         {% trans register=href('portal', 'register') %}
-          Don’t have an account yet? <a href="{{ register }}" tabindex="50">Sign up now</a>
+          Don’t have an account yet? <a href="{{ register }}">Sign up now</a>
         {% endtrans %}
       </li>
       <li>
         {% trans lost_password=href('portal', 'lost_password') %}
-          Can’t sign in? <a href="{{ lost_password }}" tabindex="60">Request a new password</a>
+          Can’t sign in? <a href="{{ lost_password }}">Request a new password</a>
         {% endtrans %}
       </li>
     </ul>

--- a/inyoka_theme_default/templates/portal/lost_password.html
+++ b/inyoka_theme_default/templates/portal/lost_password.html
@@ -18,17 +18,9 @@
 {% endblock %}
 
 {% block content %}
-<h3>{{ _('Lost password') }}</h3>
-<p>
-  {{ _('You have forgotten your password? You can obtain a new one here.') }}
-</p>
-{% if form.errors.__all__ %}{{ form.errors.__all__ }}{% endif %}
-<form action="" method="post">
-  {{ csrf_token() }}
-  {{ macros.render_form(form, ['email']) }}
+  <h3>{% trans %}Lost password{% endtrans %}</h3>
   <p>
-    <input type="submit" value="{{ _('Request new password') }}" />
+    {% trans %}You have forgotten your password? You can obtain a new one here{% endtrans %}
   </p>
-
-</form>
+  {{ macros.outer_form(csrf_token(), form, submit_label=_('Request new password')) }}
 {% endblock %}

--- a/inyoka_theme_default/templates/portal/profile.html
+++ b/inyoka_theme_default/templates/portal/profile.html
@@ -28,31 +28,18 @@
 {% endmacro %}
 
 {% block sidebar %}
-  <form action="{{ href('portal', 'user', user.username, 'unsubscribe')|e }}"
-        method="post"
-        id="unsubscribe_user">
-    {{ csrf_token() }}
-  </form>
-  <form action="{{ href('portal', 'user', user.username, 'subscribe')|e }}"
-        method="post"
-        id="subscribe_user">
-    {{ csrf_token() }}
-  </form>
 
   {% call macros.sidebar() %}
     {% if request.user.can('subscribe_to_users') %}
-      {% if is_subscribed %}
-          <input type="submit" form="unsubscribe_user" class="button-in-sidebar"
-                  title="{% trans %}Don’t watch anymore{% endtrans %}"
-                  value="{% trans %}Don’t watch anymore{% endtrans %}"
-          />
-      {% else %}
-        <input type="submit" form="subscribe_user" class="button-in-sidebar"
-                title="{% trans %}Watch{% endtrans %}"
-                value="{% trans %}Watch{% endtrans %}"
-        />
-      {% endif %}
+      {% call macros.sidebar_item() %}
+        {% if is_subscribed %}
+          {{ macros.outer_form(csrf_token(), action=href('portal', 'user', user.username, 'unsubscribe')|e , submit_label=_('Don’t watch anymore')) }}
+        {% else %}
+          {{ macros.outer_form(csrf_token(), action=href('portal', 'user', user.username, 'subscribe')|e, submit_label=_('Watch')) }}
+        {% endif %}
+      {% endcall %}
     {% endif %}
+    
     {{ macros.sidebar_item(_('Private message'), user|url('privmsg')) }}
     {{ macros.sidebar_item(_('show posts'), href('forum', 'author', user.username)) }}
   {% endcall %}

--- a/inyoka_theme_default/templates/portal/register.html
+++ b/inyoka_theme_default/templates/portal/register.html
@@ -18,55 +18,5 @@
 
 {% block content %}
   <h2>{% trans %}Sign up{% endtrans %}</h2>
-  <form action="" method="post">
-    {{ csrf_token() }}
-    {{ form.errors }}
-    <div class="form-group">
-      <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
-      <input
-          type="text"
-          id="{{ form.username.id_for_label }}"
-          name="{{ form.username.html_name }}"
-          {% if form.username.value() %}value="{{ form.username.value()|e }}"{% endif %}
-          placeholder="{% trans %}Username{% endtrans %}"
-          tabindex="10">
-    </div>
-    <div class="form-group">
-      <label for="{{ form.password.id_for_label }}">{{ form.password.label }}</label>
-      <input type="password" id="{{ form.password.id_for_label }}"
-             name="{{ form.password.html_name }}"
-             placeholder="{% trans %}Password{% endtrans %}" tabindex="10">
-    </div>
-    <div class="form-group">
-      <label for="{{ form.confirm_password.id_for_label }}">{{ form.confirm_password.label }}</label>
-      <input type="password" id="{{ form.confirm_password.id_for_label }}"
-             name="{{ form.confirm_password.html_name }}"
-             placeholder="{% trans %}Type in your password again to confirm it{% endtrans %}" tabindex="20">
-    </div>
-    <div class="form-group">
-      <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
-      <input type="email" id="{{ form.email.id_for_label }}"
-             name="{{ form.email.html_name }}"
-             {% if form.email.value() %}value="{{ form.email.value()|e }}"{% endif %}
-             placeholder="{% trans %}someone@example.com{% endtrans %}" tabindex="30">
-    </div>
-    <div class="checkbox">
-      <label>
-        {# TODO: link to terms and conditions #}
-        <input type="checkbox"
-               id="{{ form.terms_of_usage.id_for_label }}"
-               name="{{ form.terms_of_usage.html_name }}"
-               {% if form.terms_of_usage.value() %}checked{% endif %}
-               tabindex="40">{% trans %}I agree to the terms and conditions{% endtrans %}
-      </label>
-    </div>
-    <div class="form-group">
-      {# TODO: take out the HTML out of captcha and "render" it manually here #}
-      {{ form.captcha }}
-    </div>
-
-    <input type="hidden" name="redirect" value="" />
-    <input type="submit" value="{% trans %}Sign up{% endtrans %}"
-           tabindex="50" />
-  </form>
+  {{ macros.outer_form(csrf_token(), form, submit_label=_('Sign up')) }}
 {% endblock %}

--- a/inyoka_theme_default/templates/portal/user_admin.html
+++ b/inyoka_theme_default/templates/portal/user_admin.html
@@ -9,9 +9,6 @@
 #}
 {% extends 'portal/base.html' %}
 
-{% from 'macros.html' import render_form %}
-{% from 'macros.html' import render_checkbox_form %}
-
 {% block breadcrumb %}
   {{ super() }}
 

--- a/inyoka_theme_default/templates/portal/user_edit_groups.html
+++ b/inyoka_theme_default/templates/portal/user_edit_groups.html
@@ -12,17 +12,19 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li>{{_('Group memberships')}}</li>
+
+  {{ macros.breadcrumb_item(_('Group memberships'), href('portal', 'user', user.urlsafe_username, 'edit', 'groups')) }}
 {% endblock %}
 
 {% block content %}
   {{ super() }}
-  <form enctype="multipart/form-data" id="user_edit_form" method="post" action="">
-		{{ csrf_token() }}
-    <div class="page-header">
-      <h3>{% trans %}Group memberships{% endtrans %}</h3>
-    </div>
-    <table class="user_groups">
+
+  <div class="page-header">
+    <h3>{% trans %}Group memberships{% endtrans %}</h3>
+  </div>
+
+  {% call macros.outer_form(csrf_token(), form, manually_rendered=True) %}
+    <table class="user_groups form-group">
       <tr>
         <th class="col-sm-5">{% trans %}Available groups{% endtrans %}</th>
         <th class="col-sm-1"></th>
@@ -35,13 +37,11 @@
         </td>
         <td class="actions">
           <div class="center-block col-sm-1">
-            <button class="item_add btn btn-default" type="button">
-              <span alt="{% trans %}Add group{% endtrans %}"
-                class="fa_icon-arrow-right"></span>
-            </button><br />
-            <button class="item_remove btn btn-default" type="button">
-              <span alt="{% trans %}Remove group{% endtrans %}"
-                class="fa_icon-arrow-left"></span>
+            <button class="item_add btn-default">
+              <span alt="{% trans %}Add group{% endtrans %}" class="fa_icon-arrow-right"></span>
+            </button>
+            <button class="item_remove btn-default">
+              <span alt="{% trans %}Remove group{% endtrans %}" class="fa_icon-arrow-left"></span>
             </button>
           </div>
         </td>
@@ -51,14 +51,10 @@
         </td>
       </tr>
     </table>
-    <dt><div class="page-header">{{ form.primary_group.label }}</div></dt>
-    <dd>
-      {{ form.primary_group }}
-      <a href="" class="delete_primary_group">{% trans %}delete{% endtrans %}</a>
-      <p class="help-block">{{ form.primary_group.help_text }}</p>
-    </dd>
-    <input type="submit" value="{% trans %}Submit{% endtrans %}" />
-  </form>
+
+    {{ macros.input(form.primary_group) }}
+
+  {% endcall %}
 {% endblock %}
 
 {% block scripts %}

--- a/inyoka_theme_default/templates/portal/user_edit_privileges.html
+++ b/inyoka_theme_default/templates/portal/user_edit_privileges.html
@@ -1,6 +1,6 @@
 {#
     portal/user_edit_privileges.html
-    ~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Manage the privileges of a user.
 
@@ -11,29 +11,26 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li>{{_('Privileges')}}</li>
+  {{ macros.breadcrumb_item(_('Privileges'), href('portal', 'user', user.urlsafe_username, 'edit', 'privileges')) }}
 {% endblock %}
 
 {% macro render_grouplist(derived) %}
-  {% for group in derived %}<a href="{{ group|url }}">{{ group.name|e }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+  {% for group in derived %}
+    <a href="{{ group|url }}">{{ group.name|e }}</a>{% if not loop.last %}, {% endif %}
+  {% endfor %}
 {% endmacro %}
 
 {% block content %}
   {{ super() }}
-  <form enctype="multipart/form-data" id="user_edit_form" method="post" action="">
-		{{ csrf_token() }}
-    <div class="page-header">
-      <h3>{% trans %}Privileges{% endtrans %}</h3>
-    </div>
+  <div class="page-header">
+    <h3>{% trans %}Privileges{% endtrans %}</h3>
+  </div>
+  
+  {% call macros.outer_form(csrf_token(), form, manually_rendered=True) %}
+    {{ macros.render_errors(form.permissions.errors) }}
     {% for id, name, checked, derived in permissions %}
-      <input type="checkbox"
-        name="permissions"
-        value="{{ id }}"
-        id="perm_{{ id }}"
-        {% if checked %}
-          checked="checked"
-        {% endif %}
-      />
+      <input type="checkbox" name="permissions" value="{{ id }}"
+        id="perm_{{ id }}" {% if checked %} checked="checked" {% endif %} />
       <label for="perm_{{ id }}">{{ name|e }}</label>
       {% if derived %}
         <span class="text-muted">
@@ -44,7 +41,7 @@
       {% endif %}
       <br />
     {% endfor %}
-    {{ form.permissions.errors }}
+
     <h4>{% trans %}Forum privileges{% endtrans %}</h4>
     <div id="forum_rights">
       <p class="text-danger">
@@ -53,12 +50,7 @@
         {% endtrans %}
       </p>
     </div>
-    <p>
-      <input type="submit"
-        value="{% trans %}Submit{% endtrans %}"
-      />
-    </p>
-  </form>
+  {% endcall %}
 {% endblock %}
 
 {% block scripts %}

--- a/inyoka_theme_default/templates/portal/user_edit_profile.html
+++ b/inyoka_theme_default/templates/portal/user_edit_profile.html
@@ -16,20 +16,9 @@
 
 {% block content %}
   {{ super() }}
-  
+
   {% call macros.outer_form(csrf_token(), form, manually_rendered=True) %}
-    {{ macros.inner_form(form, ['username']) }}
-    
-    <dt>{{ form.member_title.label_tag() }}</dt>
-    <dd>{{ form.member_title }}
-      {% if user.groups.all() %}
-        <div class="group_titles">
-          {% for group in user.groups.all() %}
-            <input type="checkbox" name="group_titles" value="{{ group }}" /> {{ group }}
-          {% endfor %}
-        </div>
-      {% endif %}
-    </dd>
+    {{ macros.inner_form(form, ['username', 'member_title']) }}
 
     <h4>{% trans %}Avatar settings{% endtrans %}</h4>
     <div class="form-group {% if form.avatar.errors %} has-error {% endif %}">
@@ -51,7 +40,7 @@
 
     <h4>{% trans %}Contact addresses{% endtrans %}</h4>
     {{ macros.inner_form(form, ['email', 'gpgkey', 'jabber', 'icq', 'msn', 'aim', 'yim', 'skype', 'wengophone', 'sip']) }}
-    
+
     <h4>{% trans %}Miscellaneous settings{% endtrans %}</h4>
     {{ macros.inner_form(form, ['occupation', 'interests', 'website', 'launchpad', 'location']) }}
 

--- a/inyoka_theme_default/templates/portal/user_edit_profile.html
+++ b/inyoka_theme_default/templates/portal/user_edit_profile.html
@@ -1,6 +1,6 @@
 {#
     portal/user_edit_profile.html
-    ~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Change a userprofile
 
@@ -8,56 +8,53 @@
     :license: BSD, see LICENSE for more details.
 #}
 {% extends 'portal/user_admin.html' %}
-{% import 'macros.html' as macros %}
 
 {% block breadcrumb %}
   {{ super() }}
-  <li>{{_('Profile')}}</li>
+  {{ macros.breadcrumb_item(_('Profile'), href('portal', 'user', user.urlsafe_username, 'edit', 'profile')) }}
 {% endblock %}
 
 {% block content %}
   {{ super() }}
-  <form enctype="multipart/form-data" id="user_edit_form" method="post" action="">
-		{{ csrf_token() }}
-    {{ render_form(form, ['username'], inline=true) }}
-    <dt>{{ form.member_title.label_tag() }}:</dt>
+  
+  {% call macros.outer_form(csrf_token(), form, manually_rendered=True) %}
+    {{ macros.inner_form(form, ['username']) }}
+    
+    <dt>{{ form.member_title.label_tag() }}</dt>
     <dd>{{ form.member_title }}
       {% if user.groups.all() %}
-      <div class="group_titles">
-      {% for group in user.groups.all() %}
-        <input type="checkbox" name="group_titles" value="{{ group }}" /> {{ group }}
-      {% endfor %}
-      </div>
+        <div class="group_titles">
+          {% for group in user.groups.all() %}
+            <input type="checkbox" name="group_titles" value="{{ group }}" /> {{ group }}
+          {% endfor %}
+        </div>
       {% endif %}
     </dd>
 
-    <div class="page-header">
-      <h4>{% trans %}Avatar settings{% endtrans %}:</h4>
-    </div>
-    <dt>{{ form.avatar.label_tag() }}:</dt>
-    {% if user.has_avatar %}
-      <dd>{{ macros.add_user_avatar(user) }}</dd>
-    {% endif %}
-    <dd>{{ form.avatar }}</dd>
-    <dd class="note">{% trans height=avatar_height, width=avatar_width %}
-      (Will be scaled to {{ width }}x{{ height }})
-    {% endtrans %}</dd>
+    <h4>{% trans %}Avatar settings{% endtrans %}</h4>
+    <div class="form-group {% if form.avatar.errors %} has-error {% endif %}">
+      {{ form.avatar.label_tag() }}
+      {{ macros.render_errors(form.avatar.errors) }}
+      <br />
+      {% if user.has_avatar %}
+        {{ macros.add_user_avatar(user) }}
+      {% endif %}
 
-    <div class="page-header">
-      <h4>{% trans %}Contact addresses{% endtrans %}</h4>
-    </div>
-    {{ render_form(form, ['email', 'gpgkey', 'jabber', 'icq', 'msn', 'aim', 'yim', 'skype', 'wengophone', 'sip']) }}
+      {{ form.avatar }}
 
-    <div class="page-header">
-      <h4>{% trans %}Miscellaneous settings{% endtrans %}</h4>
+      <p class="help-block">
+        {% trans height=avatar_height, width=avatar_width %}
+          (Will be scaled to {{ width }}x{{ height }})
+        {% endtrans %}
+      </p>
     </div>
-    {{ render_form(form, ['occupation', 'interests', 'website',
-                          'launchpad', 'location']) }}
 
-    <div class="page-header">
-      <h4>{% trans %}Signature{% endtrans %}</h4>
-    </div>
-    <p>{{ form.signature }}</p>
-    <p><input type="submit" value="{% trans %}Submit{% endtrans %}" /></p>
-  </form>
+    <h4>{% trans %}Contact addresses{% endtrans %}</h4>
+    {{ macros.inner_form(form, ['email', 'gpgkey', 'jabber', 'icq', 'msn', 'aim', 'yim', 'skype', 'wengophone', 'sip']) }}
+    
+    <h4>{% trans %}Miscellaneous settings{% endtrans %}</h4>
+    {{ macros.inner_form(form, ['occupation', 'interests', 'website', 'launchpad', 'location']) }}
+
+    {{ macros.input(form.signature) }}
+  {% endcall %}
 {% endblock %}

--- a/inyoka_theme_default/templates/portal/user_edit_settings.html
+++ b/inyoka_theme_default/templates/portal/user_edit_settings.html
@@ -1,6 +1,6 @@
 {#
     portal/user_edit_settings.html
-    ~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Change the settings of a user.
 
@@ -11,30 +11,24 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li>{{_('Settings')}}</li>
+
+  {{ macros.breadcrumb_item(_('Settings'), href('portal', 'user', user.urlsafe_username, 'edit', 'settings')) }}
 {% endblock %}
 
 {% block content %}
   {{ super() }}
-  <form enctype="multipart/form-data" id="user_edit_form" method="post" action="">
-    {{ csrf_token() }}
+
+  {% call macros.outer_form(csrf_token(), form, manually_rendered=True) %}
     <div class="page-header">
       <h3>{% trans %}Settings{% endtrans %}</h3>
     </div>
 
-    <dl>
-      {{ render_form(form, ['notify', 'notifications', 'timezone'], inline = True) }}
+    {{ macros.inner_form(form, ['notify', 'notifications', 'timezone']) }}
 
-      <dt><h4>{% trans %}Interface{% endtrans %}</h4></dt>
-      {{ render_checkbox_form(form, ['hide_avatars', 'hide_signatures', 'hide_profile', 'highlight_search'], inline = True) }}
+    <h4>{% trans %}Interface{% endtrans %}</h4>
+    {{ macros.inner_form(form, ['hide_avatars', 'hide_signatures', 'hide_profile', 'highlight_search']) }}
 
-
-      <dt><h4>{% trans %}Forum{% endtrans %}</h4></dt>
-      {{ render_checkbox_form(form, ['mark_read_on_logout', 'autosubscribe', 'show_preview'], inline = True) }}
-      {{ render_checkbox_form(form, ['show_thumbnails'], inline = False) }}
-    </dl>
-    <p>
-      <input type="submit" value="{% trans %}Submit{% endtrans %}" />
-    </p>
-  </script>
+    <h4>{% trans %}Forum{% endtrans %}</h4>
+    {{ macros.inner_form(form, ['mark_read_on_logout', 'autosubscribe', 'show_preview', 'show_thumbnails']) }}
+  {% endcall %}
 {% endblock %}

--- a/inyoka_theme_default/templates/portal/user_edit_status.html
+++ b/inyoka_theme_default/templates/portal/user_edit_status.html
@@ -1,6 +1,6 @@
 {#
     portal/user_edit_status.html
-    ~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Change the status of a user.
 
@@ -11,50 +11,49 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li>{{_('Status')}}</li>
+
+  {{ macros.breadcrumb_item(_('State'), href('portal', 'user', user.urlsafe_username, 'edit', 'status')) }}
 {% endblock %}
 
 {% block content %}
   {{ super() }}
-  <form enctype="multipart/form-data" id="user_edit_form" method="post" action="">
-		{{ csrf_token() }}
-    <div class="page-header">
-      <h3>{% trans %}Status{% endtrans %}</h3>
+
+  <div class="page-header">
+    <h3>{% trans %}Status{% endtrans %}</h3>
+  </div>
+
+  {% call macros.outer_form(csrf_token(), form, manually_rendered=True) %}
+    {{ macros.input(form.status) }}
+
+    <div class="text-muted">
+      {% trans date=user.last_login|datetime %}
+        Last login: {{ date }}
+      {% endtrans %}
+    </div>
+    <div class="text-muted">
+      {% trans date=user.date_joined|datetime %}
+        Member since: {{ date }}
+      {% endtrans %}
+    </div>
+    <div class="text-muted">
+      {% trans link=href('portal', 'user', user.username, 'mail', next=CURRENT_URL),
+               name=user.username %}
+        <a href="{{ link }}">Send an email</a> to {{ name }}
+      {% endtrans %}
     </div>
 
-    {{ form.non_field_errors() }}
-    <dt>{{ form.status.label_tag() }}:</dt>
-    <dd>{{ form.status }} {{ form.errors.status }}
+    {% if activation_link %}
       <div class="text-muted">
-        {% trans date=user.last_login|datetime %}
-          Last login: {{ date }}
-        {% endtrans %}
+        <a href="{{ href('portal', 'users', 'resend_activation_mail', user=user, next=CURRENT_URL) }}">
+          {% trans %}Resend activation mail{% endtrans %}
+        </a>
       </div>
       <div class="text-muted">
-        {% trans date=user.date_joined|datetime %}
-          Member since: {{ date }}
-        {% endtrans %}
+        {% trans %} Activation link:{% endtrans %}
+        <a href="{{ activation_link }}">{{ activation_link }}</a>
       </div>
-      <div class="text-muted">
-        {% trans link=href('portal', 'user', user.username, 'mail', next=CURRENT_URL),
-                 name=user.username %}
-          <a href="{{ link }}">Send an email</a> to {{ name }}
-        {% endtrans %}
-      </div>
-      {% if activation_link %}
-        <div class="text-muted">
-          <a href="{{ href('portal', 'users', 'resend_activation_mail', user=user, next=CURRENT_URL) }}">
-            {% trans %}Resend activation mail{% endtrans %}
-          </a>
-        </div>
-        <div class="text-muted">
-          {% trans %} Activation link:{% endtrans %}
-          <a href="{{ activation_link }}">{{ activation_link }}</a>
-        </div>
-      {% endif %}
-    </dd>
-    {{ render_form(form, ['banned_until'], inline=true) }}
-    {{ render_form(form, ['gpgkey']) }}
-    <input type="submit" value="{% trans %}Submit{% endtrans %}" />
-  </form>
+    {% endif %}
+
+    {{ macros.inner_form(form, ['banned_until', 'gpgkey']) }}
+  {% endcall %}
 {% endblock %}

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -28,8 +28,8 @@ def mkenv(root):
         csrf_token=lambda: 'csrf_token-content'
     )
 
-    for n in ('timedeltaformat', 'hnumber', 'url', 'urlencode', 'jsonencode',
-              'naturalday', 'date', 'datetime', 'time'):
+    for n in ('date', 'datetime', 'hnumber', 'ischeckbox', 'jsonencode',
+               'naturalday', 'time', 'timedeltaformat', 'url', 'urlencode'):
         env.filters[n] = mkdummy(n)
 
     return env


### PR DESCRIPTION
- [x] checkbox-macro
- [x] `inner_form` with possibility to pass custom list of fields to
- [x] automatically select between generic input and checkboxes

enhancements
- [ ] csrf_token should not to be passed → atm wontfix
- [x] remove old macros for form-generation?
- [x] apply to existing forms → `portal/user_edit_privileges.html` and `portal/user_edit_profile.html` have to be rendered manually as they seem to have no equivalent django-forms
- [x] styling errors → known bug: border-color does not chang to red as in http://getbootstrap.com/css/#forms-control-validation

depends on https://github.com/inyokaproject/inyoka/pull/279
