### PR TITLE
Applied the breadcrumb-macro everywhere

### DIFF
--- a/inyoka_theme_default/templates/forum/base.html
+++ b/inyoka_theme_default/templates/forum/base.html
@@ -17,5 +17,5 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  <li><a href="{{ href('forum') }}">Forum</a></li>
+  {{ macros.breadcrumb_item(_('Forum'), href('forum')) }}
 {% endblock %}

--- a/inyoka_theme_default/templates/forum/edit.html
+++ b/inyoka_theme_default/templates/forum/edit.html
@@ -13,12 +13,13 @@
 
 {% block breadcrumb %}
   {{ super() }}
+
   {% if topic.forum.parent.parent %}
-    <li>…</li>
+    {{ macros.breadcrumb_item('…') }}
   {% endif %}
-  <li><a href="{{ topic.forum|url }}">{{ topic.forum }}</a></li>
-  <li><a href="{{ topic|url }}">{{ topic }}</a></li>
-  <li>{% trans %}Edit{% endtrans %}</li>
+  {{ macros.breadcrumb_item(topic.forum, topic.forum|url) }}
+  {{ macros.breadcrumb_item(topic, topic|url) }}
+  {{ macros.breadcrumb_item(_('Edit') }}
 {% endblock %}
 
 {% block content %}

--- a/inyoka_theme_default/templates/forum/forum.html
+++ b/inyoka_theme_default/templates/forum/forum.html
@@ -15,10 +15,11 @@
 
 {% block breadcrumb %}
   {{ super() }}
+
   {% if forum.parent.parent %}
-    <li><a href="{{ forum.parent|url }}">{{ forum.parent }}</a></li>
+    {{ macros.breadcrumb_item(forum.parent, forum.parent|url) }}
   {% endif %}
-  <li>{{ forum }}</li>
+  {{ macros.breadcrumb_item(forum) }}
 {% endblock %}
 
 {% block sidebar %}

--- a/inyoka_theme_default/templates/forum/topic.html
+++ b/inyoka_theme_default/templates/forum/topic.html
@@ -14,11 +14,12 @@
 
 {% block breadcrumb %}
   {{ super() }}
+
   {% if topic.forum.parent.parent %}
-    <li>…</li>
+    {{ macros.breadcrumb_item('…') }}
   {% endif %}
-  <li><a href="{{ topic.forum|url }}">{{ topic.forum }}</a></li>
-  <li>{{ topic }}</li>
+  {{ macros.breadcrumb_item(topic.forum, topic.forum|url) }}
+  {{ macros.breadcrumb_item(topic, topic|url) }}
 {% endblock %}
 
 {% block sidebar %}

--- a/inyoka_theme_default/templates/ikhaya/base.html
+++ b/inyoka_theme_default/templates/ikhaya/base.html
@@ -12,7 +12,7 @@
 {% set active_app = 'ikhaya' %}
 
 {% block breadcrumb %}
-    <li><a href="{{ href('ikhaya') }}">{% trans %}News{% endtrans %}</a></li>
+  {{ macros.breadcrumb_item(_('News'), href('ikhaya')) }}
 {% endblock %}
 
 {% block sidebar %}

--- a/inyoka_theme_default/templates/ikhaya/detail.html
+++ b/inyoka_theme_default/templates/ikhaya/detail.html
@@ -11,8 +11,8 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li><a href="{{ article.category|url }}">{{ article.category }}</a></li>
-  <li>{{ article.subject }}</li>
+  {{ macros.breadcrumb_item(article.category, article.category|url) }}
+  {{ macros.breadcrumb_item(article.subject) }}
 {% endblock %}
 
 {% block sidebar %}

--- a/inyoka_theme_default/templates/ikhaya/index.html
+++ b/inyoka_theme_default/templates/ikhaya/index.html
@@ -1,6 +1,6 @@
 {#
   ikhaya/index.html
-  ~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~~~~~~~~~~~~~~
 
   This page shows some of the latest news entries.
 
@@ -15,7 +15,7 @@
 {% block breadcrumb %}
   {{ super() }}
   {% if category %}
-    <li>{{ category }}</li>
+    {{ macros.breadcrumb_item(category) }}
   {% endif %}
 {% endblock %}
 

--- a/inyoka_theme_default/templates/pastebin/base.html
+++ b/inyoka_theme_default/templates/pastebin/base.html
@@ -12,10 +12,10 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li><a href="{{ href('pastebin') }}">{% trans %}Pastebin{% endtrans %}</a></li>
+
+  {{ macros.breadcrumb_item(_('Pastebin'), href('pastebin')) }}
 {% endblock %}
 
-{% set styles = styles|default([]) + ['pastebin'] %}
 {% set active_app = 'paste' %}
 
 {% block sidebar %}

--- a/inyoka_theme_default/templates/pastebin/browse.html
+++ b/inyoka_theme_default/templates/pastebin/browse.html
@@ -12,7 +12,8 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li><a href="{{ href('pastebin', 'browse') }}">{% trans %}Entries{% endtrans %}</a></li>
+
+  {{ macros.breadcrumb_item(_('Entries'), href('pastebin', 'browse')) }}
 {% endblock %}
 
 {% block paste_content %}

--- a/inyoka_theme_default/templates/pastebin/display.html
+++ b/inyoka_theme_default/templates/pastebin/display.html
@@ -10,12 +10,12 @@
 #}
 {% extends 'pastebin/base.html' %}
 
-{% set styles = ['highlight'] %}
 {% set scripts = ['Pastebin'] %}
 
 {% block breadcrumb %}
   {{ super() }}
-  <li><a href="{{ entry|url }}">{{ entry.title|e }}</a></li>
+
+  {{ macros.breadcrumb_item(entry.title|e, entry|url) }}
 {% endblock %}
 
 {% block sidebar %}

--- a/inyoka_theme_default/templates/planet/base.html
+++ b/inyoka_theme_default/templates/planet/base.html
@@ -11,11 +11,10 @@
 {% extends 'base.html' %}
 
 {% block breadcrumb %}
-  <li><a href="{{ href('planet') }}">{% trans %}Planet{% endtrans %}</a></li>
+  {{ macros.breadcrumb_item(_('Planet'), href('planet')) }}
 {% endblock %}
 
 {% set active_app = 'planet' %}
-{% set styles = styles|default([]) + ['planet'] %}
 
 {% block sidebar %}
   {{ planet_description_rendered|default('', True) }}

--- a/inyoka_theme_default/templates/planet/blog_edit.html
+++ b/inyoka_theme_default/templates/planet/blog_edit.html
@@ -14,13 +14,9 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li>
-    {% if not blog %}
-      {% trans %}Add blog{% endtrans %}
-    {% else %}
-      {{ blog.name|e }}
-    {% endif %}
-  </li>
+
+  {% set tmp_name = _('Add blog') if not blog else blog.name|e %}
+  {{ macros.breadcrumb_item(tmp_name) }}
 {% endblock %}
 
 {% block content %}

--- a/inyoka_theme_default/templates/planet/blog_list.html
+++ b/inyoka_theme_default/templates/planet/blog_list.html
@@ -1,6 +1,6 @@
 {#
   planet/blog_list.html
-  ~~~~~~~~~~~~~~~~
+  ~~~~~~~~~~~~~~~~~~~~~
 
   This is the overview of the static pages configuration.
 
@@ -13,7 +13,8 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li>{% trans %}Bloglist{% endtrans %}</li>
+  
+  {{ macros.breadcrumb_item(_('Bloglist')) }}
 {% endblock %}
 
 {% block content %}

--- a/inyoka_theme_default/templates/planet/suggest.html
+++ b/inyoka_theme_default/templates/planet/suggest.html
@@ -13,7 +13,8 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li>{% trans %}Suggest blog{% endtrans %}</li>
+
+  {{ macros.breadcrumb_item(_('Suggest blog')) }}
 {% endblock %}
 
 {% block planet_content %}

--- a/inyoka_theme_default/templates/portal/base.html
+++ b/inyoka_theme_default/templates/portal/base.html
@@ -13,5 +13,5 @@
 {% set active_app = 'portal' %}
 
 {% block breadcrumb %}
-  <li><a href="{{ href('portal') }}">{% trans %}Portal{% endtrans %}</a></li>
+  {{ macros.breadcrumb_item(_('Portal'), href('portal')) }}
 {% endblock %}

--- a/inyoka_theme_default/templates/portal/login.html
+++ b/inyoka_theme_default/templates/portal/login.html
@@ -12,7 +12,8 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li>{% trans %}Login{% endtrans %}</li>
+
+  {{ macros.breadcrumb_item(_('Login')) }}
 {% endblock %}
 
 {% block content %}

--- a/inyoka_theme_default/templates/portal/lost_password.html
+++ b/inyoka_theme_default/templates/portal/lost_password.html
@@ -13,6 +13,7 @@
 
 {% block breadcrumb %}
   {{ super() }}
+
   {{ macros.breadcrumb_item(_('Lost password'), href('portal', 'lost_password')) }}
 {% endblock %}
 

--- a/inyoka_theme_default/templates/portal/profile.html
+++ b/inyoka_theme_default/templates/portal/profile.html
@@ -12,8 +12,9 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li><a href="{{ href('portal', 'users') }}">{% trans %}Members{% endtrans %}</a></li>
-  <li>{{ user.username }}</li>
+
+  {{ macros.breadcrumb_item(_('Members'), href('portal', 'users')) }}
+  {{ macros.breadcrumb_item(user.username) }}
 {% endblock %}
 
 {% macro show_item(item) %}

--- a/inyoka_theme_default/templates/portal/register.html
+++ b/inyoka_theme_default/templates/portal/register.html
@@ -12,7 +12,8 @@
 
 {% block breadcrumb %}
   {{ super() }}
-  <li><a href="{{ href('portal', 'register') }}">{% trans %}Register{% endtrans %}</a></li>
+
+  {{ macros.breadcrumb_item(_('Register'), href('portal', 'register')) }}
 {% endblock %}
 
 {% block content %}

--- a/inyoka_theme_default/templates/portal/user_admin.html
+++ b/inyoka_theme_default/templates/portal/user_admin.html
@@ -15,9 +15,9 @@
 {% block breadcrumb %}
   {{ super() }}
 
-  <li><a href="{{ href('portal', 'users') }}">{% trans %}Members{% endtrans %}</a></li>
-  <li><a href="{{ USER|url }}">{{ user.username }}</a></li>
-  <li><a href="{{ href('portal', 'user', user.urlsafe_username, 'edit') }}">{{_('Edit')}}</a></li>
+  {{ macros.breadcrumb_item(_('Members'), href('portal', 'users')) }}
+  {{ macros.breadcrumb_item(user.username, USER|url) }}
+  {{ macros.breadcrumb_item(_('Edit'), href('portal', 'user', user.urlsafe_username, 'edit')) }}
 {% endblock %}
 
 {% block sidebar %}

--- a/inyoka_theme_default/templates/wiki/action_show.html
+++ b/inyoka_theme_default/templates/wiki/action_show.html
@@ -12,17 +12,19 @@
 {% extends 'wiki/base.html' %}
 
 {% block breadcrumb %}
-  <li><a href="{{ href('wiki') }}">{% block trans %}Wiki{% endblock %}</a></li>
+  {{ super() }}
+
   {% for part in page.title.split('/') %}
     {% if loop.first %}
       {% set link = href('wiki', part) %}
     {% else %}
       {% set link = link + '/' + part %}
     {% endif %}
+    
     {% if loop.last %}
-      <li class="active">{{ part }}</li>
+      {{ macros.breadcrumb_item(part) }}
     {% else %}
-      <li><a href="{{ link }}">{{ part }}</a></li>
+      {{ macros.breadcrumb_item(part, link) }}
     {% endif %}
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
The title should say it all: Replace `<li>[<a href="exmaple.org">example</a>]</li>` with `macros.breadcrumb_item(label, url)` where not already applied.
