### PR TITLE
Removed whitespace to display icons in thread-sidebar

### DIFF
--- a/inyoka_theme_default/templates/macros.html
+++ b/inyoka_theme_default/templates/macros.html
@@ -44,7 +44,7 @@
       {{ caller() }}
     {% else %}
       <a href="{{ url }}">
-        {% if icon %} <span class=" {{ icon }} "></span> {% endif %}
+        {% if icon %} <span class="{{ icon }}"></span> {% endif %}
         {{ label }}
       </a>
     {% endif %}


### PR DESCRIPTION
With the whitespace the CSS rule in [static/style/inyoka/icons.less#L13](https://github.com/inyokaproject/theme-default/blob/staging/inyoka_theme_default/static/style/inyoka/icons.less#L13) will not be applied.
Thus, no font-awesome icon will be displayed.
