### PR TITLE
begin a11y and some refactoring

### DIFF
--- a/inyoka_theme_default/static/js/smoothscrolling.js
+++ b/inyoka_theme_default/static/js/smoothscrolling.js
@@ -1,13 +1,30 @@
+/**
+ * js.smoothscrolling
+ * ~~~~~~~~~~~~~~~~~~
+ * 
+ * Smothly scroll to ids inside a document. Script includes additions for a11y.
+ * 
+ * source: http://codepen.io/theandyyates/pen/dGovD/
+ * (thus MIT licensed, see https://blog.codepen.io/legal/licensing/)
+ * 
+ * :copyright: (c) 2013-2015 by the Inyoka Team, see AUTHORS for more details.
+ * :license: BSD, see LICENSE for more details.
+ */
+
 $(function() {
-  $('a[href*=#]:not([href=#])').click(function() {
+  $('a[href*=#]:not([href=#])').click(function(event) {
     if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
-      var target = $(this.hash);
+      target = $(this.hash);
       target = target.length ? target : $('[name=' + this.hash.slice(1) +']');
       if (target.length) {
         $('html,body').animate({
-          scrollTop: target.offset().top - 60
-        }, 1000);
-        return false;
+          scrollTop: target.offset().top
+        }, 875, function(){
+          target.attr('tabindex', '-1');
+          target.focus();
+          });
+      location.hash = target;
+      return false;
       }
     }
   });

--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -32,19 +32,7 @@ html, body {
   .make-md-column(12);
 
   &-list {
-    &:extend(.breadcrumb);
-
-    & > li {
-      &:extend(.breadcrumb > li);
-
-      + li:before {
-        &:extend(.breadcrumb > li + li:before);
-      }
-
-      &:last-child, &:last-child a {
-        &:extend(.breadcrumb > .active);
-      }
-    }
+    &:extend(.breadcrumb all);
   }
 }
 

--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -129,14 +129,14 @@ html, body {
   }
 }
 
-.sidebar {
+.sidebar-group {
   &:extend(.panel);
   &:extend(.panel-default);
 
   &-danger {
     &:extend(.panel-danger);
 
-    .sidebar-heading {
+    .sidebar-group-heading {
       &:extend(.panel-heading);
       &:extend(.panel-danger > .panel-heading);
 
@@ -220,7 +220,7 @@ button, input[type="button"], input[type="submit"] {
   }
 }
 
-.sidebar form button[type="submit"] {
+.sidebar-group form button[type="submit"] {
     &:extend(a);
     &:hover, &:focus {
       &:extend(a:hover, a:focus);

--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -78,30 +78,43 @@ html, body {
   &:extend(.bg-info);
 }
 
-.message-error, .warning_important {
+
+.message {
+  &-container {
+    .make-md-column(12);
+  }
+
+  &-error {
+    &:extend(.alert);
+    &:extend(.alert-danger);
+  }
+
+  &-debug {
+    &:extend(.alert);
+    &:extend(.alert-info);
+  }
+
+  &-success {
+    &:extend(.alert);
+    &:extend(.alert-success);
+  }
+
+  &-warning {
+    &:extend(.alert);
+    &:extend(.alert-warning);
+  }
+
+  &-info {
+    &:extend(.alert);
+    &:extend(.alert-info);
+  }
+}
+
+.warning_important {
   &:extend(.alert);
   &:extend(.alert-danger);
 }
 
-.message-debug {
-  &:extend(.alert);
-  &:extend(.alert-info);
-}
-
-.message-success {
-  &:extend(.alert);
-  &:extend(.alert-success);
-}
-
-.message-warning {
-  &:extend(.alert);
-  &:extend(.alert-warning);
-}
-
-.message-info {
-  &:extend(.alert);
-  &:extend(.alert-info);
-}
 
 .pagination {
   &:extend(.pagination);

--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -22,6 +22,11 @@ html, body {
   height: 100%;
 }
 
+.skip-navigation {
+  .sr-only();
+  .sr-only-focusable();
+}
+
 .breadcrumb {
   &:extend(.breadcrumb);
 

--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -80,10 +80,6 @@ html, body {
 
 
 .message {
-  &-container {
-    .make-md-column(12);
-  }
-
   &-error {
     &:extend(.alert);
     &:extend(.alert-danger);

--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -129,48 +129,52 @@ html, body {
   }
 }
 
-.sidebar-group {
-  &:extend(.panel);
-  &:extend(.panel-default);
+.sidebar {
+  .make-sm-column(3);
 
-  &-danger {
-    &:extend(.panel-danger);
+  &-group {
+    &:extend(.panel);
+    &:extend(.panel-default);
 
-    .sidebar-group-heading {
+    &-danger {
+      &:extend(.panel-danger);
+
+      .sidebar-group-heading {
+        &:extend(.panel-heading);
+        &:extend(.panel-danger > .panel-heading);
+
+        & > h1 {
+          &:extend(.panel-title);
+        }
+      }
+    }
+
+    &-heading {
       &:extend(.panel-heading);
-      &:extend(.panel-danger > .panel-heading);
+      &:extend(.panel-default > .panel-heading);
 
       & > h1 {
         &:extend(.panel-title);
       }
     }
-  }
 
-  &-heading {
-    &:extend(.panel-heading);
-    &:extend(.panel-default > .panel-heading);
-
-    & > h1 {
-      &:extend(.panel-title);
-    }
-  }
-
-  & > ul {
-    &:extend(.list-group);
-    &:extend(.panel > .list-group);
-  }
-
-  &-item {
-    &:extend(.list-group-item);
-    &:extend(.panel > .list-group .list-group-item);
-
-    &:first-child {
-      &:extend(.panel > .list-group:first-child .list-group-item:first-child);
+    & > ul {
+      &:extend(.list-group);
+      &:extend(.panel > .list-group);
     }
 
-    &:last-child {
-      &:extend(.list-group-item:last-child);
-      &:extend(.panel > .list-group:last-child .list-group-item:last-child);
+    &-item {
+      &:extend(.list-group-item);
+      &:extend(.panel > .list-group .list-group-item);
+
+      &:first-child {
+        &:extend(.panel > .list-group:first-child .list-group-item:first-child);
+      }
+
+      &:last-child {
+        &:extend(.list-group-item:last-child);
+        &:extend(.panel > .list-group:last-child .list-group-item:last-child);
+      }
     }
   }
 }

--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -348,15 +348,21 @@ textarea {
   margin: 0;
   height: @footer-height;
 
+  &-container {
+    &:extend(.container);
+  }
+
   &-left, &-center, &-right {
     width: 33.3%;
     padding: 0 10px;
     float: left;
     &:extend(.navbar-inverse .navbar-text);
   }
+
   &-center {
     text-align: center;
   }
+
   &-right {
     text-align: right;
   }

--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -28,17 +28,21 @@ html, body {
 }
 
 .breadcrumb {
-  &:extend(.breadcrumb);
+  .make-md-column(12);
 
-  & > li {
-    &:extend(.breadcrumb > li);
+  &-list {
+    &:extend(.breadcrumb);
 
-    + li:before {
-      &:extend(.breadcrumb > li + li:before);
-    }
+    & > li {
+      &:extend(.breadcrumb > li);
 
-    &:last-child, &:last-child a {
-      &:extend(.breadcrumb > .active);
+      + li:before {
+        &:extend(.breadcrumb > li + li:before);
+      }
+
+      &:last-child, &:last-child a {
+        &:extend(.breadcrumb > .active);
+      }
     }
   }
 }

--- a/inyoka_theme_default/static/style/inyoka/inyoka.less
+++ b/inyoka_theme_default/static/style/inyoka/inyoka.less
@@ -333,6 +333,12 @@ textarea {
 }
 
 .content {
+  .make-sm-column(9);
+}
+
+.main-container {
+  &:extend(.container);
+
   @correction: 2px; /* prevents scrolling; needed because of approx. @line-height-computed (see bootstrap/variables.less, line 62)
                        and min-height: 1px of .col-sm-3 for the sidebar */
   @margin_sum: @header-height + @header-margin + @breadcrumb-height + @correction;

--- a/inyoka_theme_default/templates/base.html
+++ b/inyoka_theme_default/templates/base.html
@@ -124,8 +124,8 @@
   {% endblock %}
 
   {% block footer %}
-  <nav class="footer" id="main-footer">
-    <div class="container">
+  <footer class="footer">
+    <div class="footer-container">
       <div class="footer-left">
         {% trans link='http://inyokaproject.org/' %}
           Powered by <a href="{{ link }}">Inyoka</a>
@@ -134,7 +134,7 @@
       <div class="footer-center">Text - center</div>
       <div class="footer-right">Text - right</div>
     </div>
-  </nav>
+  </footer>
   {% endblock %}
 
   {% set extension = '.js' if SETTINGS.DEBUG else '.min.js' %}

--- a/inyoka_theme_default/templates/base.html
+++ b/inyoka_theme_default/templates/base.html
@@ -107,17 +107,15 @@
           </ol>
         </div>
 
-        <div class="col-sm-3">
-          <div class="content_sidebar" id="sidebar">
-            {% block sidebar %}
-            {% endblock %}
-          </div>
+        <div class="sidebar">
+          {% block sidebar %}
+          {% endblock %}
         </div>
+
         <div class="col-sm-9 content">
           {% block content %}
           {% endblock %}
         </div>
-
       </div>
     </div>
   </div>

--- a/inyoka_theme_default/templates/base.html
+++ b/inyoka_theme_default/templates/base.html
@@ -98,14 +98,14 @@
       </div>
       {% endfor %}
 
-      <div class="breadcrumb">
+      <div class="breadcrumb" role="navigation">
         <ol class="breadcrumb-list">
           {% block breadcrumb %}
           {% endblock %}
         </ol>
       </div>
 
-      <div class="sidebar">
+      <div class="sidebar" role="navigation">
         {% block sidebar %}
         {% endblock %}
       </div>

--- a/inyoka_theme_default/templates/base.html
+++ b/inyoka_theme_default/templates/base.html
@@ -99,9 +99,8 @@
         </div>
         {% endfor %}
 
-        <!-- Breadcrumb  like bootstrap-->
-        <div class="col-md-12">
-          <ol class="breadcrumb">
+        <div class="breadcrumb">
+          <ol class="breadcrumb-list">
             {% block breadcrumb %}
             {% endblock %}
           </ol>
@@ -116,6 +115,7 @@
           {% block content %}
           {% endblock %}
         </div>
+
       </div>
     </div>
   </div>

--- a/inyoka_theme_default/templates/base.html
+++ b/inyoka_theme_default/templates/base.html
@@ -27,6 +27,9 @@
 
 {% block body %}
 <body class="{{ active_app }}" role="document">
+  <a class="skip-navigation" href="#main-content">
+    {% trans %}Skip to main content{% endtrans %}
+  </a>
 
   {% block header %}
   <header class="header" role="navigation">

--- a/inyoka_theme_default/templates/base.html
+++ b/inyoka_theme_default/templates/base.html
@@ -119,7 +119,7 @@
   {% endblock %}
 
   {% block footer %}
-  <footer class="footer">
+  <footer class="footer" role="contentinfo">
     <div class="footer-container">
       <div class="footer-left">
         {% trans link='http://inyokaproject.org/' %}

--- a/inyoka_theme_default/templates/base.html
+++ b/inyoka_theme_default/templates/base.html
@@ -88,34 +88,31 @@
   {% endblock %}
 
   {% block main %}
-  <div class="content" id="main-content" role="main">
-    <div class="container">
-      <div class="row">
-        {% for message in MESSAGES %}
-        <div class="col-md-12">
-          <div class="message-{{ message.tags }}">
-            {{ message }}
-          </div>
+  <div class="main-container">
+    <div class="row">
+      {% for message in MESSAGES %}
+      <div class="col-md-12">
+        <div class="message-{{ message.tags }}">
+          {{ message }}
         </div>
-        {% endfor %}
+      </div>
+      {% endfor %}
 
-        <div class="breadcrumb">
-          <ol class="breadcrumb-list">
-            {% block breadcrumb %}
-            {% endblock %}
-          </ol>
-        </div>
-
-        <div class="sidebar">
-          {% block sidebar %}
+      <div class="breadcrumb">
+        <ol class="breadcrumb-list">
+          {% block breadcrumb %}
           {% endblock %}
-        </div>
+        </ol>
+      </div>
 
-        <div class="col-sm-9 content">
-          {% block content %}
-          {% endblock %}
-        </div>
+      <div class="sidebar">
+        {% block sidebar %}
+        {% endblock %}
+      </div>
 
+      <div class="content" id="main-content" role="main" target="-1">
+        {% block content %}
+        {% endblock %}
       </div>
     </div>
   </div>

--- a/inyoka_theme_default/templates/base.html
+++ b/inyoka_theme_default/templates/base.html
@@ -91,11 +91,11 @@
   <div class="main-container">
     <div class="row">
       {% for message in MESSAGES %}
-      <div class="col-md-12">
-        <div class="message-{{ message.tags }}">
-          {{ message }}
+        <div class="message-container">
+          <div class="message-{{ message.tags }}">
+            {{ message }}
+          </div>
         </div>
-      </div>
       {% endfor %}
 
       <div class="breadcrumb" role="navigation">

--- a/inyoka_theme_default/templates/base.html
+++ b/inyoka_theme_default/templates/base.html
@@ -90,13 +90,6 @@
   {% block main %}
   <div class="main-container">
     <div class="row">
-      {% for message in MESSAGES %}
-        <div class="message-container">
-          <div class="message-{{ message.tags }}">
-            {{ message }}
-          </div>
-        </div>
-      {% endfor %}
 
       <div class="breadcrumb" role="navigation">
         <ol class="breadcrumb-list">
@@ -111,6 +104,12 @@
       </div>
 
       <div class="content" id="main-content" role="main" target="-1">
+        {% for message in MESSAGES %}
+          <div class="message-{{ message.tags }}" role="alert">
+            {{ message }}
+          </div>
+        {% endfor %}
+
         {% block content %}
         {% endblock %}
       </div>

--- a/inyoka_theme_default/templates/macros.html
+++ b/inyoka_theme_default/templates/macros.html
@@ -68,26 +68,32 @@
 {# PAGINATION #}
 
 {% macro render_pagination(pagination, show_prev=True, show_next=True, threshold=2) %}
+  {% set prev_item = '<span aria-hidden="true">«</span>' %}
+  {% set next_item = '<span aria-hidden="true">»</span>' %}
+
+<nav>
   <ul class="pagination">
     {% if show_prev %}
       {% if pagination.prev %}
         <li>
-          <a href="{{ pagination.prev }}">«</a>
+          <a href="{{ pagination.prev }}" aria-label="Previous">{{ prev_item }}</a>
         </li>
       {% else %}
-        <li class="disabled">
-          <span>«</span>
-        </li>
+        <li class="disabled">{{ prev_item }}</li>
       {% endif %}
     {% endif %}
+
     {% for link in pagination.list(threshold) %}
       {% if link['type'] == 'spacer' %}
-        <li>
+        <li class="disabled">
           <span>…</span>
         </li>
       {% elif link['type'] == 'current' %}
         <li class="active">
-          <span>{{ link['page'] }}</span>
+          <span>
+            {{ link['page'] }}
+            <span class="sr-only">(current)</span>
+          </span>
         </li>
       {% else %}
         <li>
@@ -95,18 +101,18 @@
         </li>
       {% endif %}
     {% endfor %}
+
     {% if show_next %}
       {% if pagination.next %}
         <li>
-          <a href="{{ pagination.next }}">»</a>
+          <a href="{{ pagination.next }}" aria-label="Next">{{ next_item }}</a>
         </li>
       {% else %}
-        <li class="disabled">
-          <span>»</span>
-        </li>
+        <li class="disabled">{{ next_item }}</li>
       {% endif %}
     {% endif %}
   </ul>
+<nav>
 {% endmacro %}
 
 

--- a/inyoka_theme_default/templates/macros.html
+++ b/inyoka_theme_default/templates/macros.html
@@ -2,9 +2,9 @@
 
 {% macro sidebar(title) %}
 {# use as caller in combination with sidebar_item #}
-  <div class="sidebar">
+  <div class="sidebar-group">
     {% if title %}
-      <div class="sidebar-heading">
+      <div class="sidebar-group-heading">
         <h1>{{ title }}</h1>
       </div>
     {% endif %}
@@ -16,8 +16,8 @@
 
 {% macro sidebar_admin(title) %}
 {# use as caller in combination with sidebar_item #}
-<div class="sidebar sidebar-danger">
-  <div class="sidebar-heading">
+<div class="sidebar-group sidebar-group-danger">
+  <div class="sidebar-group-heading">
     {% if title %} {# necessary because gettext wont work here #}
       <h1>{{ title }}</h1>
     {% else %}
@@ -39,7 +39,7 @@
     2. as caller
        via the caller the inner content of the <li> is simply passed to it
 #}
-  <li class="sidebar-item" >
+  <li class="sidebar-group-item" >
     {% if caller %}
       {{ caller() }}
     {% else %}

--- a/inyoka_theme_default/templates/macros.html
+++ b/inyoka_theme_default/templates/macros.html
@@ -71,48 +71,48 @@
   {% set prev_item = '<span aria-hidden="true">«</span>' %}
   {% set next_item = '<span aria-hidden="true">»</span>' %}
 
-<nav>
-  <ul class="pagination">
-    {% if show_prev %}
-      {% if pagination.prev %}
-        <li>
-          <a href="{{ pagination.prev }}" aria-label="Previous">{{ prev_item }}</a>
-        </li>
-      {% else %}
-        <li class="disabled">{{ prev_item }}</li>
+  <nav>
+    <ul class="pagination">
+      {% if show_prev %}
+        {% if pagination.prev %}
+          <li>
+            <a href="{{ pagination.prev }}" aria-label="Previous">{{ prev_item }}</a>
+          </li>
+        {% else %}
+          <li class="disabled">{{ prev_item }}</li>
+        {% endif %}
       {% endif %}
-    {% endif %}
 
-    {% for link in pagination.list(threshold) %}
-      {% if link['type'] == 'spacer' %}
-        <li class="disabled">
-          <span>…</span>
-        </li>
-      {% elif link['type'] == 'current' %}
-        <li class="active">
-          <span>
-            {{ link['page'] }}
-            <span class="sr-only">(current)</span>
-          </span>
-        </li>
-      {% else %}
-        <li>
-          <a href="{{ link['url'] }}">{{ link['page'] }}</a>
-        </li>
-      {% endif %}
-    {% endfor %}
+      {% for link in pagination.list(threshold) %}
+        {% if link['type'] == 'spacer' %}
+          <li class="disabled">
+            <span>…</span>
+          </li>
+        {% elif link['type'] == 'current' %}
+          <li class="active">
+            <span>
+              {{ link['page'] }}
+              <span class="sr-only">(current)</span>
+            </span>
+          </li>
+        {% else %}
+          <li>
+            <a href="{{ link['url'] }}">{{ link['page'] }}</a>
+          </li>
+        {% endif %}
+      {% endfor %}
 
-    {% if show_next %}
-      {% if pagination.next %}
-        <li>
-          <a href="{{ pagination.next }}" aria-label="Next">{{ next_item }}</a>
-        </li>
-      {% else %}
-        <li class="disabled">{{ next_item }}</li>
+      {% if show_next %}
+        {% if pagination.next %}
+          <li>
+            <a href="{{ pagination.next }}" aria-label="Next">{{ next_item }}</a>
+          </li>
+        {% else %}
+          <li class="disabled">{{ next_item }}</li>
+        {% endif %}
       {% endif %}
-    {% endif %}
-  </ul>
-<nav>
+    </ul>
+  <nav>
 {% endmacro %}
 
 


### PR DESCRIPTION
- add skip navigation-link at top (see http://getbootstrap.com/getting-started/#skip-navigation)
- some aria-roles & -labels
- kick `.col-*`-classes in base.html
- https://github.com/inyokaproject/theme-default/commit/d934101d02a0540352c1d0b1745e81fc0965da9f →  Atm messages are not displayed at top any more on mobile devices, instead the breadcrumb and sidebar are stacked before that. Could possibly be fixed by hiding the sidebar behind a toggle-button and make the breadcrumb only one line height (+ scrollable horizontally).
