### PR TITLE
Fixed '#[object Object]'-anchor after smooth-scrolling

### DIFF
--- a/inyoka_theme_default/static/js/smoothscrolling.js
+++ b/inyoka_theme_default/static/js/smoothscrolling.js
@@ -32,7 +32,7 @@ $(document).ready(function() {
             target.focus();
           }
         });
-      location.hash = target;
+      location.hash = target.selector;
       return false;
       }
     }


### PR DESCRIPTION
Sometimes after clicking on a link on the same page and scrolling to that element,
the new hash-tag was '#[object Object]'. Now it is the same as in the clicked link.

Tested with recent versions of Chromium, Firefox & Opera
