### PR TITLE
Allow minor version updates for fontawesome

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "bootstrap": "~3.3.2",
-    "fontawesome": "~4.3.0"
+    "fontawesome": "^4.3.0"
   }
 }


### PR DESCRIPTION
Thus, fontawesome will be updated, as they currently only seem to use the minor-level.
see also https://docs.npmjs.com/misc/semver#tilde-ranges-123-12-1 ff.
