### PR TITLE
Updated jshint to ~1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-bowercopy": "^1.2.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "~0.4.0",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "~1.0.0",
     "grunt-contrib-less": "^1.0.0",
     "grunt-contrib-uglify": "~0.5.0",
     "grunt-contrib-watch": "~0.6.1",


### PR DESCRIPTION
Resolved error-message

```
 Warning: Path must be a string. Received null Use --force to continue.
```

of grunt-jshint

needs an `npm install`
